### PR TITLE
Notify that updates occurred

### DIFF
--- a/providers/build.rb
+++ b/providers/build.rb
@@ -22,4 +22,5 @@ include Teamcity::Helper
 action :download do
   initialize_connection(@new_resource.connection)
   download_all(@new_resource.destination)
+  @new_resource.updated_by_last_action(true)
 end

--- a/providers/files.rb
+++ b/providers/files.rb
@@ -21,4 +21,5 @@ include Teamcity::Helper
 action :download do
   initialize_connection(@new_resource.connection)
   download_files(@new_resource.files,@new_resource.destination)
+  @new_resource.updated_by_last_action(true)
 end


### PR DESCRIPTION
The current provider will always make updates to the resource, as it will always download the file or throw an exception.

A call to updated_by_last_action(true) is required to trigger notifications events, otherwise "notifies" won't work.
